### PR TITLE
Remove Result.ofNullable() and add static methods for Results

### DIFF
--- a/src/main/java/nwoolcan/utils/Result.java
+++ b/src/main/java/nwoolcan/utils/Result.java
@@ -78,8 +78,8 @@ public final class Result<T> {
      */
     @SuppressWarnings("unchecked")
     public <U> Result<U> map(final Function<? super T, ? extends U> mapper) {
-        Objects.requireNonNull(mapper);
-        return this.isPresent() ? Result.ofNullable(mapper.apply(this.elem.get())) : (Result<U>) this;
+        Objects.requireNonNull(mapper); //could become Results.requireNonNull
+        return this.isPresent() ? Result.of(mapper.apply(this.elem.get())) : (Result<U>) this;
     }
     /**
      * If a value is present, apply the provided {@link Result}-bearing function to it returning that {@link Result}. Otherwise return a {@link Result} holding the original exception.
@@ -89,7 +89,7 @@ public final class Result<T> {
      */
     @SuppressWarnings("unchecked")
     public <U> Result<U> flatMap(final Function<? super T, Result<U>> mapper) {
-        Objects.requireNonNull(mapper);
+        Objects.requireNonNull(mapper); //could become Results.requireNonNull
         return this.isPresent() ? mapper.apply(this.elem.get()) : (Result<U>) this;
     }
     /**

--- a/src/main/java/nwoolcan/utils/Result.java
+++ b/src/main/java/nwoolcan/utils/Result.java
@@ -133,6 +133,7 @@ public final class Result<T> {
      * If the value is not present or the value is present and matches the given predicate, return this.
      *      * Otherwise return a {@link Result} holding the specified exception.
      * @param predicate a predicate to apply to the value, if present
+     * @param exception the exception to be hold in the resulting {@link Result} if the value does not match the predicate
      * @return a {@link Result} describing the value of this Optional if a value is present and the value matches the given predicate
      */
     public Result<T> require(final Predicate<? super T> predicate, final Exception exception) {

--- a/src/main/java/nwoolcan/utils/Result.java
+++ b/src/main/java/nwoolcan/utils/Result.java
@@ -3,6 +3,7 @@ package nwoolcan.utils;
 import java.util.Objects;
 import java.util.Optional;
 import java.util.function.Function;
+import java.util.function.Predicate;
 import java.util.function.Supplier;
 
 /**
@@ -115,13 +116,32 @@ public final class Result<T> {
     public T orElse(final Supplier<? extends T> other) {
         return this.isPresent() ? this.elem.get() : other.get();
     }
-    /*
     /**
-     * If a value is present, and the value matches the given predicate, return a {@link Result} describing the value, otherwise return a {@link Result} holding the original exception.
+     * If the value is not present or the value is present and matches the given predicate, return this.
+     * Otherwise return a {@link Result} holding an {@link IllegalArgumentException}.
      * @param predicate a predicate to apply to the value, if present
      * @return a {@link Result} describing the value of this Optional if a value is present and the value matches the given predicate
-     *//*
-    Result<T> filter(Predicate<? super T> predicate);*/
+     */
+    public Result<T> require(final Predicate<? super T> predicate) {
+        if (this.isPresent()) {
+            return predicate.test(this.elem.get()) ? this : Result.error(new IllegalArgumentException());
+        } else {
+            return this;
+        }
+    }
+    /**
+     * If the value is not present or the value is present and matches the given predicate, return this.
+     *      * Otherwise return a {@link Result} holding the specified exception.
+     * @param predicate a predicate to apply to the value, if present
+     * @return a {@link Result} describing the value of this Optional if a value is present and the value matches the given predicate
+     */
+    public Result<T> require(final Predicate<? super T> predicate, final Exception exception) {
+        if (this.isPresent()) {
+            return predicate.test(this.elem.get()) ? this : Result.error(exception);
+        } else {
+            return this;
+        }
+    }
     /**
      * Indicates wheter some other object is "equal to" this {@link Result}. The other object is considered equal if:
      *  - it is also a {@link Result} and:

--- a/src/main/java/nwoolcan/utils/Result.java
+++ b/src/main/java/nwoolcan/utils/Result.java
@@ -25,15 +25,7 @@ public final class Result<T> {
      * @return a new Result<T> holding elem
      */
     public static <T> Result<T> of(final T elem) {
-        return Results.requireNonNull(elem);
-    }
-    /**
-     * @param <T> the type of elem
-     * @param elem the result to be encapsulated.
-     * @return a new Result<T> holding elem
-     */
-    public static <T> Result<T> ofNullable(final T elem) {
-        return new Result<>(Optional.ofNullable(elem), Optional.empty());
+        return new Result<>(Optional.of(elem), Optional.empty());
     }
     /**
      * @param <T> the type of the value to be returned, if any

--- a/src/main/java/nwoolcan/utils/Result.java
+++ b/src/main/java/nwoolcan/utils/Result.java
@@ -25,7 +25,7 @@ public final class Result<T> {
      * @return a new Result<T> holding elem
      */
     public static <T> Result<T> of(final T elem) {
-        return new Result<>(Optional.of(elem), Optional.empty());
+        return Results.requireNonNull(elem);
     }
     /**
      * @param <T> the type of elem

--- a/src/main/java/nwoolcan/utils/Results.java
+++ b/src/main/java/nwoolcan/utils/Results.java
@@ -1,0 +1,24 @@
+package nwoolcan.utils;
+
+/**
+ * Utilites for Result.
+ */
+public final class Results {
+
+    private Results() { }
+
+    /**
+     * Returns a {@link Result} holding elem if elem is not null, otherwise holds a NullPointerException.
+     * @param elem the elem to be tested
+     * @param <T> elem type
+     * @return a {@link Result} holding elem if elem is not null, otherwise holds a NullPointerException
+     */
+    public static <T> Result<T> requireNonNull(T elem) {
+        if (elem == null) {
+            return Result.error(new NullPointerException());
+        } else {
+            return Result.of(elem);
+        }
+    }
+
+}

--- a/src/main/java/nwoolcan/utils/Results.java
+++ b/src/main/java/nwoolcan/utils/Results.java
@@ -13,7 +13,7 @@ public final class Results {
      * @param <T> elem type
      * @return a {@link Result} holding elem if elem is not null, otherwise holds a NullPointerException
      */
-    public static <T> Result<T> requireNonNull(T elem) {
+    public static <T> Result<T> requireNonNull(final T elem) {
         if (elem == null) {
             return Result.error(new NullPointerException());
         } else {

--- a/src/main/java/nwoolcan/utils/Results.java
+++ b/src/main/java/nwoolcan/utils/Results.java
@@ -17,7 +17,7 @@ public final class Results {
         if (elem == null) {
             return Result.error(new NullPointerException());
         } else {
-            return Result.ofNullable(elem);
+            return Result.of(elem);
         }
     }
 

--- a/src/main/java/nwoolcan/utils/Results.java
+++ b/src/main/java/nwoolcan/utils/Results.java
@@ -17,7 +17,7 @@ public final class Results {
         if (elem == null) {
             return Result.error(new NullPointerException());
         } else {
-            return Result.of(elem);
+            return Result.ofNullable(elem);
         }
     }
 

--- a/src/test/java/nwoolcan/utils/TestResult.java
+++ b/src/test/java/nwoolcan/utils/TestResult.java
@@ -43,6 +43,7 @@ public class TestResult {
         assertNotEquals(present, presentEmpty);
         assertNotEquals(present, exception);
     }
+
     /**
      * Tests getting an error from a Result holding a value.
      */
@@ -51,6 +52,7 @@ public class TestResult {
         Result<Empty> empty = Result.ofEmpty();
         Exception e = empty.getError();
     }
+
     /**
      * Tests orElse.
      */
@@ -60,6 +62,7 @@ public class TestResult {
         assertTrue(error.orElse(2).equals(2));
         Integer i = error.getValue();
     }
+
     /**
      * Tests require.
      */
@@ -68,14 +71,17 @@ public class TestResult {
         assertTrue(Result.of(4).require(i -> i > 2).isPresent());
         assertTrue(Result.of(4).require(i -> i < 2).isError());
     }
+
     /**
      * Tests requireNonNull.
      */
     @Test
     public void testRequireNonNull() {
         assertTrue(Results.requireNonNull(null).isError());
-        assertTrue(Results.requireNonNull(new Empty() { }).isPresent());
+        assertTrue(Results.requireNonNull(new Empty() {
+        }).isPresent());
     }
+
     /**
      * Test map.
      */
@@ -113,8 +119,9 @@ public class TestResult {
         Result<Integer> l = duke.map(String::length);
         assertTrue(l.getValue() == 4);
     }
+
     /**
-     *  Test flatMap.
+     * Test flatMap.
      */
     @Test
     public void testFlatMap() {
@@ -152,7 +159,5 @@ public class TestResult {
         l = duke.flatMap(s -> fixture);
         assertSame(l, fixture);
     }
-
-
 }
 

--- a/src/test/java/nwoolcan/utils/TestResult.java
+++ b/src/test/java/nwoolcan/utils/TestResult.java
@@ -68,6 +68,9 @@ public class TestResult {
         assertTrue(Result.of(4).require(i -> i > 2).isPresent());
         assertTrue(Result.of(4).require(i -> i < 2).isError());
     }
+    /**
+     * Tests requireNonNull.
+     */
     @Test
     public void testRequireNonNull() {
         assertTrue(Results.requireNonNull(null).isError());

--- a/src/test/java/nwoolcan/utils/TestResult.java
+++ b/src/test/java/nwoolcan/utils/TestResult.java
@@ -61,6 +61,19 @@ public class TestResult {
         Integer i = error.getValue();
     }
     /**
+     * Tests require.
+     */
+    @Test
+    public void testRequire() {
+        assertTrue(Result.of(4).require(i -> i > 2).isPresent());
+        assertTrue(Result.of(4).require(i -> i < 2).isError());
+    }
+    @Test
+    public void testRequireNonNull() {
+        assertTrue(Results.requireNonNull(null).isError());
+        assertTrue(Results.requireNonNull(new Empty() { }).isPresent());
+    }
+    /**
      * Test map.
      */
     @Test
@@ -136,5 +149,7 @@ public class TestResult {
         l = duke.flatMap(s -> fixture);
         assertSame(l, fixture);
     }
+
+
 }
 


### PR DESCRIPTION
`Result.ofNullable()` is removed to discourage use of null values as it wouldn't have worked anyway.
New static class to hold static methods for Result: as of now `requireNonNull` is available and is very much like Objects.requireNonNull but instead of throwing an exception return a `Result` holding an error