### PR TITLE
add new methods (peek) and add supplier to flatMap and require + tests

### DIFF
--- a/src/main/java/nwoolcan/utils/Result.java
+++ b/src/main/java/nwoolcan/utils/Result.java
@@ -2,6 +2,7 @@ package nwoolcan.utils;
 
 import java.util.Objects;
 import java.util.Optional;
+import java.util.function.Consumer;
 import java.util.function.Function;
 import java.util.function.Predicate;
 import java.util.function.Supplier;
@@ -83,14 +84,37 @@ public final class Result<T> {
     }
     /**
      * If a value is present, apply the provided {@link Result}-bearing function to it returning that {@link Result}. Otherwise return a {@link Result} holding the original exception.
-     * @param mapper a mapping function to apply to the value, if present. The method is similar to {link} map(Function) but the provided mapper is one whose result is already a {@link Result}, and if invoked, flatMap does not wrap it with an additional {@link Result}.
+     * @param mapper a mapping function to apply to the value, if present. The method is similar to map(Function) but the provided mapper is one whose result is already a {@link Result}, and if invoked, flatMap does not wrap it with an additional {@link Result}.
      * @param <U> the type of the result of the mapping function
-     * @return a {link} Result describing the result of applying a mapping function to the value of this {@link Result}, if a value is present, otherwise a {@link Result} holding the original exception.
+     * @return a {@link Result} describing the result of the supplier, if a value is present, otherwise a {@link Result} holding the original exception.
      */
     @SuppressWarnings("unchecked")
     public <U> Result<U> flatMap(final Function<? super T, Result<U>> mapper) {
         Objects.requireNonNull(mapper); //could become Results.requireNonNull
         return this.isPresent() ? mapper.apply(this.elem.get()) : (Result<U>) this;
+    }
+    /**
+     * If a value is present, apply the provided {@link Result}-bearing function to it returning that {@link Result}. Otherwise return a {@link Result} holding the original exception.
+     * @param supplier a supplier of {@link Result<U>}
+     * @param <U> the type of the result of the supplier
+     * @return a {@link Result} describing the result of the supplier, if a value is present, otherwise a {@link Result} holding the original exception.
+     */
+    @SuppressWarnings("unchecked")
+    public <U> Result<U> flatMap(final Supplier<Result<U>> supplier) {
+        Objects.requireNonNull(supplier); //could become Results.requireNonNull
+        return this.isPresent() ? supplier.get() : (Result<U>) this;
+    }
+    /**
+     * If a value is present, execute the provided {@link Consumer}.
+     * @param action a non-interfering action to perform on the element
+     * @return this
+     */
+    public Result<T> peek(final Consumer<? super T> action) {
+        Objects.requireNonNull(action); //could become Results.requireNonNull
+        return this.map(elem -> {
+            action.accept(elem);
+            return elem;
+        });
     }
     /**
      * Return the value if present, otherwise return other.
@@ -112,25 +136,44 @@ public final class Result<T> {
      * If the value is not present or the value is present and matches the given predicate, return this.
      * Otherwise return a {@link Result} holding an {@link IllegalArgumentException}.
      * @param predicate a predicate to apply to the value, if present
-     * @return a {@link Result} describing the value of this Optional if a value is present and the value matches the given predicate
+     * @return a {@link Result} describing the value of this {@link Result} if a value is present and the value matches the given predicate
      */
     public Result<T> require(final Predicate<? super T> predicate) {
-        if (this.isPresent()) {
-            return predicate.test(this.elem.get()) ? this : Result.error(new IllegalArgumentException());
-        } else {
-            return this;
-        }
+        return this.require(predicate, new IllegalArgumentException());
     }
     /**
      * If the value is not present or the value is present and matches the given predicate, return this.
      *      * Otherwise return a {@link Result} holding the specified exception.
      * @param predicate a predicate to apply to the value, if present
      * @param exception the exception to be hold in the resulting {@link Result} if the value does not match the predicate
-     * @return a {@link Result} describing the value of this Optional if a value is present and the value matches the given predicate
+     * @return a {@link Result} describing the value of this {@link Result} if a value is present and the value matches the given predicate
      */
     public Result<T> require(final Predicate<? super T> predicate, final Exception exception) {
         if (this.isPresent()) {
             return predicate.test(this.elem.get()) ? this : Result.error(exception);
+        } else {
+            return this;
+        }
+    }
+    /**
+     * If the value is not present or the value is present and the predicate is true, return this.
+     * Otherwise return a {@link Result} holding an {@link IllegalArgumentException}.
+     * @param supplier a supplier of a boolean condition
+     * @return a {@link Result} describing the value of this {@link Result} if a value is present and the condition is true
+     */
+    public Result<T> require(final Supplier<Boolean> supplier) {
+        return this.require(supplier, new IllegalArgumentException());
+    }
+    /**
+     * If the value is not present or the value is present and the predicate is true, return this.
+     * Otherwise return a {@link Result} holding the specified exception.
+     * @param supplier a supplier of a boolean condition
+     * @param exception the exception to be hold in the resulting {@link Result} if the value does not match the predicate
+     * @return a {@link Result} describing the value of this {@link Result} if a value is present and the condition is true
+     */
+    public Result<T> require(final Supplier<Boolean> supplier, final Exception exception) {
+        if (this.isPresent()) {
+            return supplier.get() ? this : Result.error(exception);
         } else {
             return this;
         }

--- a/src/test/java/nwoolcan/utils/ResultTest.java
+++ b/src/test/java/nwoolcan/utils/ResultTest.java
@@ -2,6 +2,8 @@ package nwoolcan.utils;
 
 import org.junit.Test;
 
+import java.util.ArrayList;
+import java.util.Collection;
 import java.util.NoSuchElementException;
 import java.util.Optional;
 
@@ -70,6 +72,8 @@ public class ResultTest {
     public void testRequire() {
         assertTrue(Result.of(4).require(i -> i > 2).isPresent());
         assertTrue(Result.of(4).require(i -> i < 2).isError());
+        assertTrue(Result.ofEmpty().require(() -> false).isError());
+        assertTrue(Result.ofEmpty().require(() -> true).isPresent());
     }
 
     /**
@@ -158,6 +162,18 @@ public class ResultTest {
         // Verify same instance
         l = duke.flatMap(s -> fixture);
         assertSame(l, fixture);
+        assertEquals(l.flatMap(() -> Result.of(4)), Result.of(4));
+    }
+
+    /**
+     * Tests peek.
+     */
+    public void testPeek() {
+        Collection<Integer> coll = new ArrayList<>();
+        Result.of(2).peek(coll::add);
+        assertEquals(coll.size(), 1);
+        Result.error(new Exception()).peek(i -> coll.add(2));
+        assertEquals(coll.size(), 1);
     }
 }
 


### PR DESCRIPTION
* Add new method `peek` (just like the `peek` from Stream)
* Add supplier option for `flatMap` and `require`. This is done to simplify notation, you can now write:
```Result.ofEmpty().flatMap(() -> Result.of(2)).require(() -> true)```
Do not abuse of this, when possible stick to the traditional methods.
