### PR TITLE
Zeegomo/result/new methods

### DIFF
--- a/src/main/java/nwoolcan/utils/Results.java
+++ b/src/main/java/nwoolcan/utils/Results.java
@@ -1,5 +1,9 @@
 package nwoolcan.utils;
 
+import java.util.concurrent.Callable;
+import java.util.function.Function;
+import java.util.function.Supplier;
+
 /**
  * Utilites for Result.
  */
@@ -20,5 +24,36 @@ public final class Results {
             return Result.of(elem);
         }
     }
-
+    /**
+     * Return a {@link Result} holding the value produced by callable, if everything goes well.
+     * Otherwise return a {@link Result} holding the exception thrown by callable.
+     * Use this to avoid try-catch blocks.
+     * @param callable the function to call
+     * @param <T> the type of the {@link Result}
+     * @return a {@link Result}
+     */
+    public static <T> Result<T> ofChecked(final Callable<T> callable) {
+        try {
+            return Result.of(callable.call());
+        } catch (Exception e) {
+            return Result.error(e);
+        }
+    }
+    /**
+     * Return a {@link Result} holding the value produced by function, in everything goes well.
+     * Otherwise return a {@link Result} holding the exception thrown by closing resource.
+     * Use this to avoid try with resource.
+     * @param resource the resource being used
+     * @param function the function to call.
+     * @param <T> the type of the Result.
+     * @param <U> the type of the resource.
+     * @return a {@link Result}
+     */
+    public static <T, U extends AutoCloseable> Result<T> ofCloseable(final Supplier<U> resource, final Function<U, T> function) {
+        try (U elem = resource.get()) {
+            return Result.of(function.apply(elem));
+        } catch (Exception e) {
+            return Result.error(e);
+        }
+    }
 }

--- a/src/test/java/nwoolcan/utils/ResultTest.java
+++ b/src/test/java/nwoolcan/utils/ResultTest.java
@@ -168,6 +168,7 @@ public class ResultTest {
     /**
      * Tests peek.
      */
+    @Test
     public void testPeek() {
         Collection<Integer> coll = new ArrayList<>();
         Result.of(2).peek(coll::add);
@@ -175,5 +176,36 @@ public class ResultTest {
         Result.error(new Exception()).peek(i -> coll.add(2));
         assertEquals(coll.size(), 1);
     }
+
+    /**
+     * Tests ofChecked.
+     */
+    @Test
+    public void testOfChecked() {
+        Result<Integer> r1 = Results.ofChecked(() -> 1);
+        assertTrue(r1.getValue() == 1);
+        Result<Integer> r2 = Results.ofChecked(() -> {
+            throw new IllegalAccessException("Illegal test");
+        });
+        assertTrue(r2.isError());
+        r2.getError().printStackTrace();
+        System.out.println(r2.getError().toString());
+    }
+
+    /**
+     * Tests ofCloseable.
+     */
+    @Test
+    public void testOfCloseable() {
+        Result<Integer> r1 = Results.ofCloseable(() -> () -> { }, e -> 3);
+        assertTrue(r1.getValue() == 3);
+        Result<Integer> r2 = Results.ofCloseable(() -> () -> {
+            throw new IllegalAccessException();
+            }, e -> 3);
+        assertTrue(r2.isError());
+        r2.getError().printStackTrace();
+        System.out.println(r2.getError().toString());
+    }
+
 }
 


### PR DESCRIPTION
Add new methods to Results, in particular:
- 'Result<T> ofChecked(Callable<T> callable)' accepts a function that takes no argument and may throw an exception and return a Result holding the result of the function, if any, otherwise the exception throw.
- 'Result<U> ofCloseable(Callable<T extends AutoCloseable> resource, Function<T, U> function' accept a function that return the resource to be closed at the end, and another function that is the body of the sobstituted try with resource that accept the resource previously opened