### PR TITLE
Refactor check on illegal Quantity and simplify UnitOfMeasure

### DIFF
--- a/.idea/codeStyles/Project.xml
+++ b/.idea/codeStyles/Project.xml
@@ -3,6 +3,7 @@
     <option name="LINE_SEPARATOR" value="&#10;" />
     <option name="RIGHT_MARGIN" value="100" />
     <codeStyleSettings language="JAVA">
+      <option name="ALIGN_MULTILINE_CHAINED_METHODS" value="true" />
       <indentOptions>
         <option name="CONTINUATION_INDENT_SIZE" value="4" />
       </indentOptions>

--- a/src/main/java/nwoolcan/model/utils/Quantity.java
+++ b/src/main/java/nwoolcan/model/utils/Quantity.java
@@ -1,14 +1,13 @@
 package nwoolcan.model.utils;
 
+import nwoolcan.utils.Result;
+
 import java.util.Objects;
 
 /**
  * Quantity class for handling value and unit of measure.
  */
 public final class Quantity {
-
-    private static final String VALUE_NEGATIVE_MESSAGE = "Value cannot be negative.";
-    private static final String CANNOT_BE_QUANTITY_MESSAGE = "Unit of measure cannot be a quantity.";
 
     private final Number value;
     private final UnitOfMeasure unitOfMeasure;
@@ -46,14 +45,11 @@ public final class Quantity {
      * @throws IllegalArgumentException if the value is negative or if the unit of measure cannot be a quantity.
      */
     public static Quantity of(final Number value, final UnitOfMeasure unitOfMeasure) {
-        final Quantity res = new Quantity(value, unitOfMeasure);
-        if (res.getValue().doubleValue() < 0) {
-            throw new IllegalArgumentException(VALUE_NEGATIVE_MESSAGE);
+        final Result<Quantity> res = QuantityChecker.check(new Quantity(value, unitOfMeasure));
+        if (res.isError()) {
+            throw new IllegalArgumentException(res.getError());
         }
-        if (!res.getUnitOfMeasure().canBeQuantity()) {
-            throw new IllegalArgumentException(CANNOT_BE_QUANTITY_MESSAGE);
-        }
-        return res;
+        return res.getValue();
     }
 
     @Override

--- a/src/main/java/nwoolcan/model/utils/QuantityChecker.java
+++ b/src/main/java/nwoolcan/model/utils/QuantityChecker.java
@@ -1,0 +1,36 @@
+package nwoolcan.model.utils;
+
+import nwoolcan.utils.Result;
+
+import java.util.Arrays;
+import java.util.Collection;
+
+/**
+ * Utils class that performs a check on a {@link Quantity} object.
+ */
+public final class QuantityChecker {
+
+    private static final String VALUE_NEGATIVE_MESSAGE = "Value cannot be negative.";
+    private static final String CANNOT_BE_QUANTITY_MESSAGE = "Unit of measure cannot be a quantity.";
+
+    private static final Collection<UnitOfMeasure> VALID_UMS = Arrays.asList(
+        UnitOfMeasure.Liter,
+        UnitOfMeasure.Kilogram,
+        UnitOfMeasure.Pound
+    );
+
+    private QuantityChecker() { }
+
+    /**
+     * Performs a check on the {@link Quantity} passed by parameter, returning a {@link Result}
+     * with a {@link IllegalArgumentException} error if the quantity value is null or the quantity
+     * unit of measure is not valid for a quantity, otherwise with the same quantity passed by parameter.
+     * @param quantity quantity to check.
+     * @return a {@link Result} with same quantity if the check passes, with an error otherwise.
+     */
+    public static Result<Quantity> check(final Quantity quantity) {
+        return Result.of(quantity)
+                     .require(q -> q.getValue().doubleValue() > 0, new IllegalArgumentException(VALUE_NEGATIVE_MESSAGE))
+                     .require(q -> VALID_UMS.contains(q.getUnitOfMeasure()), new IllegalArgumentException(CANNOT_BE_QUANTITY_MESSAGE));
+    }
+}

--- a/src/main/java/nwoolcan/model/utils/UnitOfMeasure.java
+++ b/src/main/java/nwoolcan/model/utils/UnitOfMeasure.java
@@ -7,37 +7,5 @@ public enum UnitOfMeasure {
     /**
      * Unit of measures that can be used as quantity and parameter.
      */
-    Kilogram, Liter, Pound,
-    /**
-     * Unit of measures that cannot be used as quantity.
-     */
-    Celsius(false, true);
-
-    private boolean canBeQuantity;
-    private boolean canBeParameter;
-
-    UnitOfMeasure() {
-        this(true, true);
-    }
-
-    UnitOfMeasure(final boolean canBeQuantity, final boolean canBeParameter) {
-        this.canBeQuantity = canBeQuantity;
-        this.canBeParameter = canBeParameter;
-    }
-
-    /**
-     * Returns true if the unit of measure can be used as a quantity, false instead.
-     * @return true if the unit of measure can be used as a quantity, false instead.
-     */
-    public boolean canBeQuantity() {
-        return this.canBeQuantity;
-    }
-
-    /**
-     * Returns true if the unit of measure can be used as a parameter, false instead.
-     * @return true if the unit of measure can be used as a parameter, false instead.
-     */
-    public boolean canBeParameter() {
-        return this.canBeParameter;
-    }
+    Kilogram, Liter, Pound, Celsius;
 }


### PR DESCRIPTION
Refactor UnitOfMeasure checks to be on Quantity-side instead of boolean fields in UnitOfMeasure creation.
Remember to add the unit of measure to the QuantityChecker internal collection if you want to use a new unit of measure for the quantities.