### PR TITLE
add new methods toEmpty and stream for Result and relevant tests

### DIFF
--- a/src/main/java/nwoolcan/utils/Result.java
+++ b/src/main/java/nwoolcan/utils/Result.java
@@ -6,6 +6,7 @@ import java.util.function.Consumer;
 import java.util.function.Function;
 import java.util.function.Predicate;
 import java.util.function.Supplier;
+import java.util.stream.Stream;
 
 /**
  * Result.
@@ -179,6 +180,27 @@ public final class Result<T> {
         }
     }
     /**
+     * Return a {@link Optional}  describing the value if present. Otherwise returns an empty {@link Optional}
+     * @return a {@link Optional} describing the value if present, or an empty {@link Optional} if this {@link Result} hold an exception
+     */
+    public Optional<T> toOptional() {
+        return this.isPresent() ? Optional.of(this.elem.get()) : Optional.empty();
+    }
+    /**
+     * Map this {@link Result} to a {@link Result<Empty>}.
+     * @return a {@link Result<Empty>}.
+     */
+    public Result<Empty> toEmpty() {
+        return this.flatMap(Result::ofEmpty);
+    }
+    /**
+     * Returns a {@link Stream} with this {@link Result} as its source.
+     * @return a {@link Stream<Result>>}.
+     */
+    public Stream<Result<T>> stream() {
+        return Stream.of(this);
+    }
+    /**
      * Indicates whether some other object is "equal to" this {@link Result}. The other object is considered equal if:
      *  - it is also a {@link Result} and:
      *  - the present values are "equal to" each other via equals().
@@ -201,7 +223,7 @@ public final class Result<T> {
         }
     }
     /**
-     * Returns a non-empty string representation of this {@link Result} suitable for debugging. The exact presentation format is unspecified and may vary between implementations and versions.
+     * Return a non-empty string representation of this {@link Result} suitable for debugging. The exact presentation format is unspecified and may vary between implementations and versions.
      * @return the string representation of this instance
      */
     @Override
@@ -209,18 +231,11 @@ public final class Result<T> {
         return this.isPresent() ? this.elem.get().toString() : this.exception.get().toString();
     }
     /**
-     * Returns the hash code value of the present value, if any, or 0 if no value is present.
+     * Return the hash code value of the present value, if any, or 0 if no value is present.
      * @return hash code value of the present value or 0
      */
     @Override
     public int hashCode() {
         return this.isPresent() ? this.elem.get().hashCode() : 0;
-    }
-    /**
-     * Return a {@link Optional}  describing the value if present. Otherwise returns an empty {@link Optional}
-     * @return a {@link Optional} describing the value if present, or an empty {@link Optional} if this {@link Result} hold an exception
-     */
-    public Optional<T> toOptional() {
-        return this.isPresent() ? Optional.of(this.elem.get()) : Optional.empty();
     }
 }

--- a/src/test/java/nwoolcan/utils/ResultTest.java
+++ b/src/test/java/nwoolcan/utils/ResultTest.java
@@ -45,7 +45,6 @@ public class ResultTest {
         assertNotEquals(present, presentEmpty);
         assertNotEquals(present, exception);
     }
-
     /**
      * Tests getting an error from a Result holding a value.
      */
@@ -54,7 +53,6 @@ public class ResultTest {
         Result<Empty> empty = Result.ofEmpty();
         Exception e = empty.getError();
     }
-
     /**
      * Tests orElse.
      */
@@ -64,7 +62,6 @@ public class ResultTest {
         assertTrue(error.orElse(2).equals(2));
         Integer i = error.getValue();
     }
-
     /**
      * Tests require.
      */
@@ -75,7 +72,6 @@ public class ResultTest {
         assertTrue(Result.ofEmpty().require(() -> false).isError());
         assertTrue(Result.ofEmpty().require(() -> true).isPresent());
     }
-
     /**
      * Tests requireNonNull.
      */
@@ -85,7 +81,6 @@ public class ResultTest {
         assertTrue(Results.requireNonNull(new Empty() {
         }).isPresent());
     }
-
     /**
      * Test map.
      */
@@ -123,7 +118,6 @@ public class ResultTest {
         Result<Integer> l = duke.map(String::length);
         assertTrue(l.getValue() == 4);
     }
-
     /**
      * Test flatMap.
      */
@@ -164,7 +158,6 @@ public class ResultTest {
         assertSame(l, fixture);
         assertEquals(l.flatMap(() -> Result.of(4)), Result.of(4));
     }
-
     /**
      * Tests peek.
      */
@@ -176,7 +169,6 @@ public class ResultTest {
         Result.error(new Exception()).peek(i -> coll.add(2));
         assertEquals(coll.size(), 1);
     }
-
     /**
      * Tests ofChecked.
      */
@@ -191,7 +183,6 @@ public class ResultTest {
         r2.getError().printStackTrace();
         System.out.println(r2.getError().toString());
     }
-
     /**
      * Tests ofCloseable.
      */
@@ -206,6 +197,27 @@ public class ResultTest {
         r2.getError().printStackTrace();
         System.out.println(r2.getError().toString());
     }
+    /**
+     * Tests stream.
+     */
+    @Test
+    public void testStream() {
+        Result<Integer> r1 = Result.of(2);
+        assertEquals(r1.stream().distinct().count(), 1);
+        assertTrue(r1.stream().allMatch(i -> i.getValue() == 2));
+        assertEquals(r1.stream().findAny().get(), Result.of(2));
+    }
+    /**
+     * Tests toEmpty.
+     */
+    @Test
+    public void testToEmpty() {
+        Result<Integer> r1 = Result.of(2);
+        assertTrue(r1.toEmpty().isPresent());
 
+        Result<Integer> r2 = Results.requireNonNull(null);
+        assertFalse(r2.toEmpty().isPresent());
+        assertTrue(r2.toEmpty().isError());
+    }
 }
 

--- a/src/test/java/nwoolcan/utils/ResultTest.java
+++ b/src/test/java/nwoolcan/utils/ResultTest.java
@@ -151,12 +151,12 @@ public class ResultTest {
         Result<Integer> fixture = Result.of(Integer.MAX_VALUE);
         l = duke.flatMap(s -> Result.of(s.length()));
         assertTrue(l.isPresent());
-        assertEquals(l.getValue().intValue(), 4);
+        assertEquals(4, l.getValue().intValue());
 
         // Verify same instance
         l = duke.flatMap(s -> fixture);
         assertSame(l, fixture);
-        assertEquals(l.flatMap(() -> Result.of(4)), Result.of(4));
+        assertEquals(Result.of(4), l.flatMap(() -> Result.of(4)));
     }
     /**
      * Tests peek.
@@ -165,9 +165,9 @@ public class ResultTest {
     public void testPeek() {
         Collection<Integer> coll = new ArrayList<>();
         Result.of(2).peek(coll::add);
-        assertEquals(coll.size(), 1);
+        assertEquals(1, coll.size());
         Result.error(new Exception()).peek(i -> coll.add(2));
-        assertEquals(coll.size(), 1);
+        assertEquals(1, coll.size());
     }
     /**
      * Tests ofChecked.
@@ -203,9 +203,9 @@ public class ResultTest {
     @Test
     public void testStream() {
         Result<Integer> r1 = Result.of(2);
-        assertEquals(r1.stream().distinct().count(), 1);
+        assertEquals(1, r1.stream().distinct().count());
         assertTrue(r1.stream().allMatch(i -> i.getValue() == 2));
-        assertEquals(r1.stream().findAny().get(), Result.of(2));
+        assertEquals(Result.of(2), r1.stream().findAny().get());
     }
     /**
      * Tests toEmpty.


### PR DESCRIPTION
Add two new methods for `Result`:
* `toEmpty`: map the current `Result<T>` to a `Result<Empty>`, short version for `flatMap(Result::ofEmpty)`
* `stream`: return a `Stream<Result<T>>`, short version for `Stream.of(this)` 