### PR TITLE
Add javadoc step in gradle check task

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,6 +7,4 @@ cache:
   directories:
     - $HOME/.gradle/caches/
     - $HOME/.gradle/wrapper/
-script:
-  - ./gradlew check
-  - ./gradlew javadoc
+

--- a/.travis.yml
+++ b/.travis.yml
@@ -7,4 +7,3 @@ cache:
   directories:
     - $HOME/.gradle/caches/
     - $HOME/.gradle/wrapper/
-

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -26,3 +26,7 @@ dependencies {
 configure<JavaPluginConvention> {
     sourceCompatibility = JavaVersion.VERSION_1_8
 }
+
+tasks.named("check") {
+    dependsOn("javadoc")
+}


### PR DESCRIPTION
Add javadoc step in gradle check task to easily test also the javadoc correctness. Now `check` runs all the necessary tests and it is the same config as Travis

closes #44 